### PR TITLE
Catch KeyboardInterrupt gracefully

### DIFF
--- a/zk_soundness_checker.py
+++ b/zk_soundness_checker.py
@@ -20,4 +20,10 @@ def verify_zk_contract(address):
     print("✅ Verification complete — code integrity verified for zk environment.")
 
 if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\nAborted by user.", file=sys.stderr)
+        sys.exit(130)
+
     verify_zk_contract(CONTRACT_ADDRESS)


### PR DESCRIPTION
Avoid stacktraces if user hits Ctrl+C mid-run.