### PR TITLE
Add --no-color reserved flag for future formatting

### DIFF
--- a/quick_check.py
+++ b/quick_check.py
@@ -12,6 +12,12 @@ def parse_args():
         required=True,
         help="Path to input JSON file with check results."
     )
+        parser.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Reserved: disable colored output if added in the future.",
+    )
+
     parser.add_argument(
         "--verbose",
         action="store_true",


### PR DESCRIPTION
Forward-compatible knob; you don’t have to implement coloring now.