### PR TITLE
Fix the argmparse typo in the return type

### DIFF
--- a/list_failures.py
+++ b/list_failures.py
@@ -3,8 +3,7 @@ import argparse
 import json
 import sys
 
-
-def parse_args() -> argmparse.Namespace:
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Print failing checks from a JSON results file."
     )


### PR DESCRIPTION
The type hint currently references a non-existing name and will crash if type checkers run it.