### PR TITLE
Use ArgumentDefaultsHelpFormatter for nicer --help

### DIFF
--- a/list_failures.py
+++ b/list_failures.py
@@ -6,7 +6,8 @@ import sys
 
 def parse_args() -> argmparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Print failing checks from a JSON results file."
+        description="Print failing checks from a JSON results file.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
         "--input",


### PR DESCRIPTION
Shows default values automatically in the help message