### PR TITLE
Feature: add argument parsing for custom contract addresses

### DIFF
--- a/zk_soundness_checker.py
+++ b/zk_soundness_checker.py
@@ -31,8 +31,17 @@ def verify_zk_contract(address):
     print(f"ZK Soundness Hash: {zk_hash}")
     print("✅ Verification complete — code integrity verified for zk environment.")
 
+import argparse
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Verify ZK contract code integrity.")
+    parser.add_argument("--contract-address", required=True, help="Contract address to verify.")
+    return parser.parse_args()
+
 if __name__ == "__main__":
-    verify_zk_contract(CONTRACT_ADDRESS)
+    args = parse_args()
+    verify_zk_contract(args.contract_address)
+
 import time
 start = time.time()
 # ... основной код ...


### PR DESCRIPTION
## Summary

The current script is hardcoded to work with a single contract address. It would be more flexible to allow the user to pass a contract address as a command‑line argument.

## Proposed Changes

- Use `argparse` to parse a `--contract-address` argument.  
- Allow users to pass any contract address for verification.

## Motivation

- Increases the usability and flexibility of the script.
- Allows the tool to be used with any contract on Ethereum or other compatible blockchains.