### PR TITLE
Chore: add error handling for failed RPC requests

### DIFF
--- a/zk_soundness_checker.py
+++ b/zk_soundness_checker.py
@@ -22,7 +22,12 @@ def verify_zk_contract(address):
 
         print("❌ Connection to RPC failed.")
         sys.exit(1)
+   try:
     code = w3.eth.get_code(Web3.to_checksum_address(address))
+except Exception as e:
+    print(f"❌ Error fetching contract code: {e}", file=sys.stderr)
+    sys.exit(2)
+
     print(f"🧩 Contract code length: {len(code)} bytes")
 
     zk_hash = hashlib.sha256(code).hexdigest()


### PR DESCRIPTION
## Summary

If the RPC request fails for any reason (e.g., network issues, rate limits), the current script will silently fail. This PR adds better error handling for failed RPC calls.

## Proposed Changes

- Add error handling for `w3.eth.get_code()` failure.
- Provide detailed error messages if RPC connection fails or if the contract code fetch fails.

## Motivation

- Enhances the robustness of the script by preventing silent failures.
- Improves user feedback in case of errors.