### PR TITLE
Feature: add --quiet flag to suppress non‑essential logs

### DIFF
--- a/zk_soundness_checker.py
+++ b/zk_soundness_checker.py
@@ -31,8 +31,21 @@ def verify_zk_contract(address):
     print(f"ZK Soundness Hash: {zk_hash}")
     print("✅ Verification complete — code integrity verified for zk environment.")
 
+import argparse
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Verify ZK contract code integrity.")
+    parser.add_argument("--contract-address", required=True, help="Contract address to verify.")
+    p.add_argument("--quiet", action="store_true", help="Suppress non-essential logs.")
+if args.quiet:
+    logger.setLevel(logging.ERROR)
+
+    return parser.parse_args()
+
 if __name__ == "__main__":
-    verify_zk_contract(CONTRACT_ADDRESS)
+    args = parse_args()
+    verify_zk_contract(args.contract_address)
+
 import time
 start = time.time()
 # ... основной код ...


### PR DESCRIPTION
## Summary

Sometimes, users may want to suppress informational logs and only see errors. This PR introduces a `--quiet` flag that reduces output verbosity.

## Proposed Changes

- Implement a `--quiet` flag that suppresses all non‑error logs.
- Use `logging` to respect the quiet mode.

## Motivation

- Allows users to run the script without cluttering the terminal with unnecessary logs.