### PR TITLE
Feature: implement EIP-191 signing for attestation

### DIFF
--- a/zk_soundness_checker.py
+++ b/zk_soundness_checker.py
@@ -11,6 +11,12 @@ import sys
 import hashlib
 # Simple verifier script for on-chain ZK contract soundness
 import os
+from eth_account import Account
+
+def sign_attestation(payload, private_key):
+    account = Account.from_key(private_key)
+    signed_msg = Account.sign_message(encode_defunct(primitive=payload), private_key)
+    return signed_msg.signature.hex()
 
 RPC_URL = os.getenv("RPC_URL", "https://mainnet.infura.io/v3/your_api_key")
 CONTRACT_ADDRESS = "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32"  # Example contract


### PR DESCRIPTION
## Summary

To make the verification results more trustworthy, users can sign the attestation with their private key. This PR implements EIP-191 signing for the attestation.

## Proposed Changes

- Integrate signing functionality using the `eth_account` library for EIP-191.
- Allow users to optionally sign the attestation before outputting it.

## Motivation

- Enhances security and credibility by ensuring that the attestation was signed by a trusted entity.